### PR TITLE
fix: update obfuscator to use owo.vc v2 api

### DIFF
--- a/src/commands/obfuscator.ts
+++ b/src/commands/obfuscator.ts
@@ -28,7 +28,10 @@ const obfuscator: Command = {
 
         const r = await fetch('https://owo.vc/api/v2/link', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'User-Agent': 'AdramelechBot (https://github.com/Abysm0xC/AdramelechBot)',
+                'Content-Type': 'application/json'
+            },
             body: JSON.stringify({ 'link': url, 'generator': 'sketchy', 'metadata': 'IGNORE' }),
         });
 

--- a/src/commands/obfuscator.ts
+++ b/src/commands/obfuscator.ts
@@ -26,10 +26,10 @@ const obfuscator: Command = {
 
         (rawURL.startsWith('https://' || 'http://')) ? url = rawURL : url = 'https://' + rawURL;
 
-        const r = await fetch('https://owo.vc/generate', {
+        const r = await fetch('https://owo.vc/api/v2/link', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ 'link': url, 'generator': 'sketchy', 'preventScrape': true }),
+            body: JSON.stringify({ 'link': url, 'generator': 'sketchy', 'metadata': 'IGNORE' }),
         });
 
         if (r.status !== 200) {


### PR DESCRIPTION
Hiya,

this pull request updates the functionality in the obfuscator command to use the owo.vc v2 API. The update was released a few days ago, and I figured that I'd open pull requests to the projects that I knew of to speed up adoption of the new API. Full API changes can be read about here: https://owo.vc/changelog.html#2023-04-01

Thanks for using owo.vc :>